### PR TITLE
Add tests for PlayerGamesOverview

### DIFF
--- a/game_overview.py
+++ b/game_overview.py
@@ -47,10 +47,12 @@ class PlayerGamesOverview:
                             }
     
     def get_data(self, year, month):
+        """Return a DataFrame of the player's games for the given month."""
         month = str(month).zfill(2)  # Ensure month is two digits
         url = f'{self.link}/{year}/{month}'
-        
-        self.create_player_games_table(fetch_json(url))
+
+        data = fetch_json(url)
+        return self.create_player_games_table(data)
         # response = requests.get(url, headers=self.headers)
         # if response.status_code == 200:    
         #     data = response.json()
@@ -80,8 +82,28 @@ class PlayerGamesOverview:
         self.df_games = pd.DataFrame(games_data)
         self.df_games["Date"] = pd.to_datetime(self.df_games["Date"], unit='s')
         self.df_games['game_value'] = self.df_games['Result'].map(self.game_values).astype(int)
-        
+
         return self.df_games
+
+    def win_rate(self):
+        """Return win/loss/draw counts and win rate for the loaded games."""
+        if not hasattr(self, 'df_games'):
+            raise ValueError("No games loaded. Call get_data first.")
+
+        total_games = len(self.df_games)
+        total_wins = (self.df_games['game_value'] == 1).sum()
+        total_losses = (self.df_games['game_value'] == -1).sum()
+        total_draws = (self.df_games['game_value'] == 0).sum()
+        win_rate = total_wins / total_games if total_games else 0
+
+        return {
+            'total_games': int(total_games),
+            'total_wins': int(total_wins),
+            'total_losses': int(total_losses),
+            'total_draws': int(total_draws),
+            'win_rate': win_rate,
+            'win_rate_100_base': win_rate * 100
+        }
     
     def analyze_res_vs_opening(self):
         

--- a/tests/test_game_overview.py
+++ b/tests/test_game_overview.py
@@ -1,0 +1,33 @@
+import json
+import re
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import game_overview
+from game_overview import PlayerGamesOverview
+
+
+def _load_local_games():
+    text = Path('2025-05_chess_games.json').read_text()
+    pattern = re.compile(r'"pgn": "((?:\\.|[^"\\])*?)"', re.DOTALL)
+    fixed = pattern.sub(lambda m: '"pgn": "' + m.group(1).replace("\n", "\\n") + '"', text)
+    return json.loads(fixed)
+
+
+def test_get_data_and_win_rate(monkeypatch):
+    data = _load_local_games()
+
+    monkeypatch.setattr(game_overview, 'fetch_json', lambda url: data)
+
+    pgo = PlayerGamesOverview('Frezaeei')
+    df = pgo.get_data(2025, 5)
+    assert isinstance(df, pd.DataFrame)
+
+    stats = pgo.win_rate()
+    assert isinstance(stats, dict)
+    assert stats['total_games'] == len(df)
+    total = stats['total_wins'] + stats['total_losses'] + stats['total_draws']
+    assert total == len(df)
+


### PR DESCRIPTION
## Summary
- return DataFrame from `PlayerGamesOverview.get_data`
- add `win_rate` helper method
- add pytest verifying win rate totals with local data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846b79d882883268f5db27a05d68e36